### PR TITLE
Add support for configurable username parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,14 @@ server {
 ```
 
 
+### Using nginx-dynamic-acl without basic authentication
+This library automatically determines the username based on the `ngx.var.remote_user` value that is defined when using basic auth. If you are using another authentication method and just want to
+use nginx-dynamic-acl for authorization, you can provide a second parameter to the `.authorize(...)` call as follows:
+
+```
+require("dynamic_acl").authorize("<location to your authorizations JSON file>", "<username from somewhere else>")
+```
+
 ## Credits and acknowledgements
 * Created by [Niels Nijens](http://github.com/niels-nijens).
 * Inspired by [Playing HTTP Tricks with Nginx](https://www.elastic.co/blog/playing-http-tricks-nginx) by [Elastic](https://github.com/elastic).

--- a/src/dynamic_acl.lua
+++ b/src/dynamic_acl.lua
@@ -7,8 +7,10 @@ local dynamicACL = {
 }
 
 -- Authorizes authenticated users for specific configured paths.
-function dynamicACL.authorize(authorizationsFile)
-    local username = ngx.var.remote_user
+function dynamicACL.authorize(authorizationsFile, username)
+    if username == nil then
+        username = ngx.var.remote_user
+    end
     ngx.log(ngx.DEBUG, role)
 
     local authorizations = dynamicACL.loadAuthorizations(authorizationsFile)

--- a/src/dynamic_acl.lua
+++ b/src/dynamic_acl.lua
@@ -11,7 +11,7 @@ function dynamicACL.authorize(authorizationsFile, username)
     if username == nil then
         username = ngx.var.remote_user
     end
-    ngx.log(ngx.DEBUG, role)
+    ngx.log(ngx.DEBUG, username)
 
     local authorizations = dynamicACL.loadAuthorizations(authorizationsFile)
 


### PR DESCRIPTION
Hello @niels-nijens, 

I'd like to use this library for ACL, but I'm not using basic auth. I'm actually using a different nginx/lua library that does authentication via JWT, which does not inject the username into `ngx.var.remote_user`. As far as I can tell, that value is readonly unless nginx itself is updating it.

The aim of this pull request is to preserve the existing behavior (i.e., grab the username from `ngx.var.remote_user` automatically), _but_ allow the username to be supplied as an optional 2nd parameter to use instead. This should provide a bit more flexibility while not breaking the existing functionality for anybody.

This is my first attempt at tweaking Lua code, so please do feel free to correct any mistakes that wouldn't be obvious to a novice.